### PR TITLE
Add autosubscribe argument to fetchFullAccount.

### DIFF
--- a/lib/chain/src/ChainStore.js
+++ b/lib/chain/src/ChainStore.js
@@ -453,7 +453,7 @@ class ChainStore
     *  @return undefined if the object might exist but is not in cache
     *  @return the object if it does exist and is in our cache
     */
-    fetchObject( id, force = false )
+    fetchObject( id, force = false, autosubscribe = true )
     {
         if( typeof id !== "string" )
         {
@@ -470,7 +470,7 @@ class ChainStore
         if( !ChainValidation.is_object_id(id) )
             throw Error( "argument is not an object id: " + id );
 
-        if( id.search("1.2.") === 0 ) return this.fetchFullAccount( id );
+        if( id.search("1.2.") === 0 ) return this.fetchFullAccount( id, autosubscribe );
         if (id.search(witness_prefix) === 0) this._subTo("witnesses", id);
         if (id.search(committee_prefix) === 0) this._subTo("committee", id);
 
@@ -504,7 +504,7 @@ class ChainStore
     *  @return undefined if such an account may exist, and fetch the the full account if not already pending
     *  @return the account object if it does exist
     */
-    getAccount( name_or_id ) {
+    getAccount( name_or_id, autosubscribe = true ) {
 
         if( !name_or_id )
             return null;
@@ -523,7 +523,7 @@ class ChainStore
                 return null;
             }
             if( account === undefined || account.get("name") === undefined ) {
-                return this.fetchFullAccount( name_or_id );
+                return this.fetchFullAccount( name_or_id, autosubscribe );
             }
             return account;
         }
@@ -532,7 +532,7 @@ class ChainStore
             let account_id = this.accounts_by_name.get( name_or_id );
             if(account_id === null) return null; // already fetched and it wasn't found
             if( account_id === undefined ) // then no query, fetch it
-                return this.fetchFullAccount( name_or_id );
+                return this.fetchFullAccount( name_or_id, autosubscribe );
 
             return this.getObject( account_id ); // return it
         }
@@ -738,7 +738,7 @@ class ChainStore
     *  @return the object if it has already been fetched
     *  @return null if the object has been queried and was not found
     */
-    fetchFullAccount( name_or_id )
+    fetchFullAccount( name_or_id, autosubscribe = true )
     {
         if(DEBUG) console.log( "Fetch full account: ", name_or_id );
 
@@ -761,7 +761,7 @@ class ChainStore
         if( !this.fetching_get_full_accounts.has(name_or_id) || (Date.now() - this.fetching_get_full_accounts.get(name_or_id)) > 5000  ) {
             this.fetching_get_full_accounts.set(name_or_id, Date.now() );
             //console.log( "FETCHING FULL ACCOUNT: ", name_or_id )
-            Apis.instance().db_api().exec("get_full_accounts", [[name_or_id],true])
+            Apis.instance().db_api().exec("get_full_accounts", [[name_or_id], autosubscribe])
             .then( results => {
                 if(results.length === 0 ) {
                     if( ChainValidation.is_object_id(name_or_id) ) {


### PR DESCRIPTION
Whenever fetchFullAccount is called, the server auto-subscribes the client to receive notifications when data about the account changes. This can be problematic when fetching data for over 100 accounts. On the server side, an assertion fails and causes an exception to be thrown. On the client side, this error is ignored and the client continues to repeat the the get_full_account command about every 5 seconds. This can cause significant lag in the client as network and processing cycles are continually wasted on operations that will never succeed. This commit allows a client to decide if it should attempt to be auto-subscribed or not.