### PR TITLE
Date serialization: a bug fix for time zone

### DIFF
--- a/lib/serializer/src/types.js
+++ b/lib/serializer/src/types.js
@@ -319,10 +319,10 @@ Types.time_point_sec = {
             return Math.floor( object.getTime() / 1000 );
 
         if(typeof object !== "string")
-            throw new Error("Unknown date type: " + object)
+            throw new Error("Unknown date type: " + object);
 
-        // if(typeof object === "string" && !/Z$/.test(object))
-        //     object = object + "Z"
+        if(/T[0-2][0-9]:[0-5][0-9]:[0-5][0-9]$/.test(object))
+             object = object + "Z";
 
         return Math.floor( new Date(object).getTime() / 1000 );
     },


### PR DESCRIPTION
some cases new Date('2017-12-29T04:53:00') will parse it for UTC,
but in other cases for Local Time. append Z in this case to force UTC,
as per in blockchain data.