### PR TITLE
Update hash.js

### DIFF
--- a/lib/ecc/src/hash.js
+++ b/lib/ecc/src/hash.js
@@ -38,9 +38,11 @@ function HmacSHA256(buffer, secret) {
 }
 
 function ripemd160(data) {
-    return createHash("rmd160")
-        .update(data)
-        .digest();
+    try{
+        return createHash('rmd160').update(data).digest();
+    } catch(e){
+        return createHash('ripemd160').update(data).digest();
+    }
 }
 
 // function hash160(buffer) {


### PR DESCRIPTION
Fixing digest warning

Related issue: https://github.com/bitshares/bitsharesjs/issues/92
Related EOS JS library fix: https://github.com/EOSIO/eosjs-ecc/commit/1014cb74f9ebe8ebd48318720a1e8208c5a2f495