### PR TITLE
Changing import methods

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,10 +1,19 @@
-module.exports = {
-    PrivateKey: require("./ecc/src/PrivateKey"),
-    PublicKey: require("./ecc/src/PublicKey"),
-    Signature: require("./ecc/src/signature"),
-    key: require("./ecc/src/KeyUtils"),
-    TransactionBuilder: require("./chain/src/TransactionBuilder"),
-    Login: require("./chain/src/AccountLogin"),
-    bitshares_ws: require("bitsharesjs-ws"),
-    aes: require("./ecc/src/aes")
-}
+import { PrivateKey } from "./ecc/src/PrivateKey";
+import { PublicKey } from "./ecc/src/PublicKey";
+import { Signature } from "./ecc/src/signature";
+import * as key from "./ecc/src/KeyUtils";
+import { TransactionBuilder } from "./chain/src/TransactionBuilder";
+import { AccountLogin as Login } from "./chain/src/AccountLogin";
+import * as bitshares_ws from "bitsharesjs-ws";
+import { aes } from "./ecc/src/aes";
+ 
+export {
+  PrivateKey,
+  PublicKey,
+  Signature,
+  key,
+  TransactionBuilder,
+  Login,
+  bitshares_ws,
+  aes
+};

--- a/lib/chain/src/TransactionBuilder.js
+++ b/lib/chain/src/TransactionBuilder.js
@@ -3,7 +3,7 @@ import {Signature, PublicKey, hash} from "../../ecc";
 import {ops} from "../../serializer";
 import {Apis, ChainConfig} from "bitsharesjs-ws";
 import ChainTypes from "./ChainTypes";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 var head_block_time_string, committee_min_review;
 

--- a/lib/ecc/src/KeyUtils.js
+++ b/lib/ecc/src/KeyUtils.js
@@ -6,7 +6,7 @@ import {sha256, sha512} from "./hash";
 // import dictionary from './dictionary_en';
 import secureRandom from "secure-random";
 import {ChainConfig} from "bitsharesjs-ws";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 // hash for .25 second
 var HASH_POWER_MILLS = 250;

--- a/lib/ecc/src/PrivateKey.js
+++ b/lib/ecc/src/PrivateKey.js
@@ -8,7 +8,7 @@ import assert from "assert";
 
 const secp256k1 = getCurveByName("secp256k1");
 const {n} = secp256k1;
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 class PrivateKey {
     /**

--- a/lib/ecc/src/PublicKey.js
+++ b/lib/ecc/src/PublicKey.js
@@ -6,7 +6,7 @@ import {sha256, sha512, ripemd160} from "./hash";
 import {ChainConfig} from "bitsharesjs-ws";
 import assert from "assert";
 import deepEqual from "deep-equal";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 const {G, n} = secp256k1;
 
 class PublicKey {

--- a/lib/ecc/src/address.js
+++ b/lib/ecc/src/address.js
@@ -3,7 +3,7 @@ import {ChainConfig} from "bitsharesjs-ws";
 import {sha256, sha512, ripemd160} from "./hash";
 import {encode, decode} from "bs58";
 import deepEqual from "deep-equal";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 /** Addresses are shortened non-reversable hashes of a public key.  The full PublicKey is preferred.
  */

--- a/lib/ecc/src/aes.js
+++ b/lib/ecc/src/aes.js
@@ -4,7 +4,7 @@ import encHex from "crypto-js/enc-hex";
 import encBase64 from "crypto-js/enc-base64";
 import assert from "assert";
 import {sha256, sha512} from "./hash";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 /** Provides symetric encrypt and decrypt via AES. */
 class Aes {

--- a/lib/ecc/src/ecdsa.js
+++ b/lib/ecc/src/ecdsa.js
@@ -4,7 +4,7 @@ import enforceType from "./enforce_types";
 
 import BigInteger from "bigi";
 import ECSignature from "./ecsignature";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 // https://tools.ietf.org/html/rfc6979#section-3.2
 function deterministicGenerateK(curve, hash, d, checkSig, nonce) {

--- a/lib/ecc/src/ecsignature.js
+++ b/lib/ecc/src/ecsignature.js
@@ -1,7 +1,7 @@
 import assert from "assert"; // from https://github.com/bitcoinjs/bitcoinjs-lib
 import enforceType from "./enforce_types";
 import BigInteger from "bigi";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 function ECSignature(r, s) {
     enforceType(BigInteger, r);

--- a/lib/ecc/src/signature.js
+++ b/lib/ecc/src/signature.js
@@ -5,7 +5,7 @@ var secp256k1 = getCurveByName("secp256k1");
 import assert from "assert";
 import BigInteger from "bigi";
 import PublicKey from "./PublicKey";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 class Signature {
     constructor(r1, s1, i1) {

--- a/lib/serializer/src/FastParser.js
+++ b/lib/serializer/src/FastParser.js
@@ -1,5 +1,5 @@
 import PublicKey from "../../ecc/src/PublicKey";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 class FastParser {
     static fixed_data(b, len, buffer) {

--- a/lib/serializer/src/convert.js
+++ b/lib/serializer/src/convert.js
@@ -1,5 +1,5 @@
 import ByteBuffer from "bytebuffer";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 export default function(type) {
     return {

--- a/lib/serializer/src/serializer.js
+++ b/lib/serializer/src/serializer.js
@@ -1,6 +1,6 @@
 import ByteBuffer from "bytebuffer";
 import EC from "./error_with_cause";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 const HEX_DUMP = process.env.npm_config__graphene_serializer_hex_dump;
 

--- a/lib/serializer/src/types.js
+++ b/lib/serializer/src/types.js
@@ -10,7 +10,7 @@ import {PublicKey, Address} from "../../ecc";
 import {ChainConfig} from "bitsharesjs-ws";
 
 import ByteBuffer from "bytebuffer";
-const Buffer = require("safe-buffer").Buffer;
+import { Buffer } from "safe-buffer";
 
 var Types = {};
 


### PR DESCRIPTION
The CJS format of importing packages like `require("safe-buffer").Buffer` causes issues in Tauri.

Proposing switching from require to using import methods more extensively.

All tests pass, but I've not yet been able to test if it resolves the error in tauri.

If this won't work, then perhaps we replace safe-buffer altogether? https://github.com/feross/safe-buffer/issues/32