### PR TITLE
Introduce suez support

### DIFF
--- a/lib/serializer/src/operations.js
+++ b/lib/serializer/src/operations.js
@@ -472,6 +472,25 @@ export const credit_deal_expired_operation_fee_parameters = new Serializer(
     {}
 );
 
+export const liquidity_pool_update_operation_fee_parameters = new Serializer(
+    "liquidity_pool_update_operation_fee_parameters",
+    {
+        fee: uint64,
+    }
+);
+
+export const credit_deal_update_operation_fee_parameters = new Serializer(
+    "credit_deal_update_operation_fee_parameters",
+    {
+        fee: uint64,
+    }
+);
+
+export const limit_order_update_operation_fee_parameters = new Serializer(
+    "limit_order_update_operation_fee_parameters",
+    { fee: uint64 }
+);
+
 
 var fee_parameters = static_variant([
     transfer_operation_fee_parameters,
@@ -548,7 +567,10 @@ var fee_parameters = static_variant([
     credit_offer_update_operation_fee_parameters,
     credit_offer_accept_operation_fee_parameters,
     credit_deal_repay_operation_fee_parameters,
-    credit_deal_expired_operation_fee_parameters
+    credit_deal_expired_operation_fee_parameters,
+    liquidity_pool_update_operation_fee_parameters,
+    credit_deal_update_operation_fee_parameters,
+    limit_order_update_operation_fee_parameters,
 ]);
 
 export const fee_schedule = new Serializer("fee_schedule", {
@@ -618,6 +640,16 @@ export const transfer = new Serializer("transfer", {
     extensions: set(future_extensions)
 });
 
+export const create_take_profit_order_action = new Serializer("create_take_profit_order_action", {
+    fee_asset_id: protocol_id_type("asset"),
+    spread_percent: uint16,
+    size_percent: uint16,
+    expiration_seconds: uint32,
+    repeat: bool,
+});
+
+var limit_order_auto_action = static_variant([create_take_profit_order_action]);
+
 export const limit_order_create = new Serializer("limit_order_create", {
     fee: asset,
     seller: protocol_id_type("account"),
@@ -625,7 +657,12 @@ export const limit_order_create = new Serializer("limit_order_create", {
     min_to_receive: asset,
     expiration: time_point_sec,
     fill_or_kill: bool,
-    extensions: set(future_extensions)
+    extensions: extension([
+        {
+            name: "on_fill",
+            type: array(limit_order_auto_action),
+        },
+    ]),
 });
 
 export const limit_order_cancel = new Serializer("limit_order_cancel", {
@@ -1553,6 +1590,36 @@ export const credit_deal_expired = new Serializer("credit_deal_expired", {
     fee_rate: uint32
 });
 
+// Op 75: liquidity_pool_update_operation
+export const liquidity_pool_update = new Serializer("liquidity_pool_update", {
+    fee: asset,
+    account: protocol_id_type("account"),
+    pool: protocol_id_type("liquidity_pool"),
+    taker_fee_percent: optional(uint16),
+    withdrawal_fee_percent: optional(uint16),
+    extensions: set(future_extensions),
+});
+
+// Op 76: credit_deal_update_operation
+export const credit_deal_update = new Serializer("credit_deal_update", {
+    fee: asset,
+    account: protocol_id_type("account"),
+    deal_id: protocol_id_type("credit_deal"),
+    auto_repay: uint8,
+    extensions: set(future_extensions),
+});
+
+// Op 77: limit_order_update_operation
+export const limit_order_update = new Serializer("limit_order_update", {
+    fee: asset,
+    account_id_type: protocol_id_type("account"),
+    limit_order_id_type: protocol_id_type("limit_order"),
+    new_price: optional(price),
+    delta_amount_to_sell: optional(asset),
+    new_expiration: optional(time_point_sec),
+    on_fill: optional(array(limit_order_auto_action)),
+});
+
 operation.st_operations = [
     transfer,
     limit_order_create,
@@ -1628,7 +1695,10 @@ operation.st_operations = [
     credit_offer_update,
     credit_offer_accept,
     credit_deal_repay,
-    credit_deal_expired
+    credit_deal_expired,
+    liquidity_pool_update,
+    credit_deal_update,
+    limit_order_update,
 ];
 
 export const transaction = new Serializer("transaction", {


### PR DESCRIPTION
Supports 3 new operations:,
* liquidity_pool_update
* credit_deal_update
* limit_order_update

Introduce support for on_fill limit_order_auto_action create_take_profit_order_action (OSO support) in limit_order_create
