### PR TITLE
Fix nested proposal fee asset id formatting

### DIFF
--- a/lib/chain/src/TransactionBuilder.js
+++ b/lib/chain/src/TransactionBuilder.js
@@ -422,14 +422,10 @@ class TransactionBuilder {
             if (isProposal(op)) {
                 op[1].proposed_ops.forEach(proposal => {
                     proposed_ops.push(proposal);
-                    if (
-                        proposalFeeAssets.indexOf(
-                            proposal.op[1].fee.asset_id
-                        ) === -1
-                    ) {
-                        proposalFeeAssets.push(
-                            proposal.op[1].fee.asset_id
-                        );
+                    const _feeID = proposal.op[1].fee.asset_id;
+                    if (proposalFeeAssets.indexOf(_feeID) === -1) {
+                        const formattedFeeID = _feeID.includes("1.3.") ? _feeID : `1.3.${_feeID}`;
+                        proposalFeeAssets.push(formattedFeeID);
                     }
                 });
             }

--- a/lib/chain/src/TransactionBuilder.js
+++ b/lib/chain/src/TransactionBuilder.js
@@ -426,10 +426,11 @@ class TransactionBuilder {
                         proposalFeeAssets.indexOf(
                             proposal.op[1].fee.asset_id
                         ) === -1
-                    )
+                    ) {
                         proposalFeeAssets.push(
-                            "1.3." + proposal.op[1].fee.asset_id
+                            proposal.op[1].fee.asset_id
                         );
+                    }
                 });
             }
             if (!isDuplicate) {


### PR DESCRIPTION
Addresses issue: https://github.com/bitshares/bitsharesjs/issues/137

When creating a proposal, we were incorrectly formatting nested proposal fee asset id's as "1.3.1.3.0" for example, now it's just the fee asset id which fixes the encountered issue.